### PR TITLE
Weak reference to ViewController in WeatherLocationRouter (avoid retain cycle)

### DIFF
--- a/Weather/Modules/WeatherLocation/Router/WeatherLocationRouter.swift
+++ b/Weather/Modules/WeatherLocation/Router/WeatherLocationRouter.swift
@@ -10,7 +10,7 @@ protocol WeatherLocationRouter {
 
 class WeatherLocationModalRouter: WeatherLocationRouter {
     
-    let viewController: UIViewController
+    weak var viewController: UIViewController?
     
     init(viewController: UIViewController) {
         self.viewController = viewController
@@ -19,6 +19,6 @@ class WeatherLocationModalRouter: WeatherLocationRouter {
     // MARK: <WeatherLocationRouter>
     
     func navigateBack() {
-        self.viewController.dismissViewControllerAnimated(true, completion: nil)
+        self.viewController?.dismissViewControllerAnimated(true, completion: nil)
     }
 }


### PR DESCRIPTION
Hi Nicola,
Thank you very much for your talk. I like your architecture and I would try to implement in some projects :)

It is a simple PR but solve a retain cycle that there is in the project, when you present modal view controller (WeatherLocationViewcontroller).
At the next image, you can see that the number of WeatherLocationViewcontroller allocations :)

![captura de pantalla 2016-10-25 a las 8 57 22](https://cloud.githubusercontent.com/assets/6462202/19676011/17c396e2-9a92-11e6-8f3c-5cf54b45d4b4.png)

Thanks for the example project.
